### PR TITLE
Initialize frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Bluum-rasp
+
+This project contains a simple full stack setup with a Vite/Three.js frontend and an Express backend.
+
+## Development
+
+Install dependencies and start both servers:
+
+```bash
+npm install
+npm run dev
+```
+
+The frontend will be served via Vite and the backend via Express.
+
+## Production Build
+
+```bash
+npm run build
+npm start
+```

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname, '..', 'frontend', 'dist')));
+
+app.get('/api', (req, res) => {
+  res.json({ message: 'Hello from Express!' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "backend",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "nodemon index.js",
+    "build": "echo 'No build step for backend'",
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Three.js Vite App</title>
+  </head>
+  <body>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "three": "^0.155.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,23 @@
+import * as THREE from 'three';
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer();
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const geometry = new THREE.BoxGeometry();
+const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+const cube = new THREE.Mesh(geometry, material);
+scene.add(cube);
+
+camera.position.z = 5;
+
+function animate() {
+  requestAnimationFrame(animate);
+  cube.rotation.x += 0.01;
+  cube.rotation.y += 0.01;
+  renderer.render(scene, camera);
+}
+
+animate();

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist'
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bluum-rasp",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "concurrently \"npm run --prefix backend dev\" \"npm run --prefix frontend dev\"",
+    "build": "npm run --prefix frontend build && npm run --prefix backend build",
+    "start": "node backend/index.js"
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.1"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold frontend Vite app with Three.js placeholder
- scaffold Express.js backend server
- add root scripts to run both parts
- document usage in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453abeb5cc8330a43f6dceb46bc839